### PR TITLE
fix: resolve shell quote escaping error in tmux popup command

### DIFF
--- a/lua/q-cli-neovim/init.lua
+++ b/lua/q-cli-neovim/init.lua
@@ -34,10 +34,10 @@ end
 function utils.command_exists(cmd)
   local handle = io.popen('which ' .. cmd .. ' 2>/dev/null')
   if not handle then return false end
-  
+
   local result = handle:read('*a')
   handle:close()
-  
+
   return result ~= ''
 end
 
@@ -47,11 +47,11 @@ end
 function utils.execute_command(cmd)
   local result = vim.fn.system(cmd)
   local success = vim.v.shell_error == 0
-  
+
   if not success then
     return false, result
   end
-  
+
   return true, nil
 end
 
@@ -71,14 +71,14 @@ function utils.validate_config(config)
       message = 'startup_timeout must be a positive number'
     },
   }
-  
+
   for _, validation in ipairs(validations) do
     local value = config[validation.field]
     if not validation.check(value) then
       return false, validation.message
     end
   end
-  
+
   return true, nil
 end
 
@@ -111,26 +111,26 @@ function session.create(name, cwd)
   local success, error_msg = utils.execute_command(
     string.format('tmux new-session -d -s %s -c "%s"', name, cwd)
   )
-  
+
   if not success then
     return false, 'Failed to create tmux session: ' .. (error_msg or 'unknown error')
   end
-  
+
   -- Set up environment
   utils.execute_command(string.format('tmux send-keys -t %s "export PAGER=cat" Enter', name))
-  
+
   -- Build Q CLI command
   local q_cmd = 'q chat'
   if state.config.trust_all_tools then
     q_cmd = q_cmd .. ' --trust-all-tools'
   end
-  
+
   -- Start Q CLI
   utils.execute_command(string.format('tmux send-keys -t %s "%s" Enter', name, q_cmd))
-  
+
   -- Wait for startup
   vim.wait(state.config.startup_timeout)
-  
+
   return true, nil
 end
 
@@ -147,17 +147,17 @@ end
 function session.list_all()
   local handle = io.popen('tmux list-sessions -F "#{session_name}" 2>/dev/null | grep "^q-cli-"')
   if not handle then return {} end
-  
+
   local sessions_output = handle:read('*a')
   handle:close()
-  
+
   if sessions_output == '' then return {} end
-  
+
   local sessions = {}
   for session_name in sessions_output:gmatch('[^\r\n]+') do
     table.insert(sessions, session_name)
   end
-  
+
   return sessions
 end
 
@@ -169,22 +169,22 @@ local tmux = {}
 function tmux.get_prefix()
   local handle = io.popen('tmux show-options -g prefix 2>/dev/null')
   if not handle then return 'Ctrl+B' end
-  
+
   local result = handle:read('*a')
   handle:close()
-  
+
   if not result or result == '' then return 'Ctrl+B' end
-  
+
   local prefix = result:match('prefix%s+(.-)%s*\n?$')
   if not prefix then return 'Ctrl+B' end
-  
+
   -- Convert tmux format to human readable
   local prefix_map = {
     ['C-b'] = 'Ctrl+B',
     ['C-s'] = 'Ctrl+S',
     ['C-a'] = 'Ctrl+A',
   }
-  
+
   return prefix_map[prefix] or prefix:gsub('C%-', 'Ctrl+')
 end
 
@@ -199,25 +199,26 @@ end
 --- @return boolean success, string? error_message
 function tmux.open_popup(session_name)
   local prefix_key = tmux.get_prefix()
-  
+
   local popup_cmd = string.format([[
     tmux display-popup \
       -w 85%% \
       -h 75%% \
       -x C \
       -y C \
-      -T " Amazon Q CLI (%s d to close)" \
+      -T ' Amazon Q CLI (%s d to close)' \
       -b "rounded" \
       -E "tmux attach-session -t %s"
-  ]], prefix_key, session_name)
-  
+  ]], prefix_key, vim.fn.shellescape(session_name))
+
   local success, error_msg = utils.execute_command(popup_cmd)
   if not success then
     return false, 'Failed to open popup: ' .. (error_msg or 'unknown error')
   end
-  
+
   return true, nil
 end
+
 
 -- Environment validation
 local env = {}
@@ -228,11 +229,11 @@ function env.validate()
   if not tmux.is_available() then
     return false, 'Not running in tmux session'
   end
-  
+
   if not utils.command_exists('q') then
     return false, 'Amazon Q CLI not found. Please install it first.'
   end
-  
+
   return true, nil
 end
 
@@ -241,21 +242,21 @@ end
 function M.toggle()
   local initialized, init_error = check_initialized()
   if not initialized then return end
-  
+
   -- Validate environment
   local env_valid, env_error = env.validate()
   if not env_valid then
     vim.notify(env_error, vim.log.levels.ERROR)
     return
   end
-  
+
   -- Get or create session
   local session_name = session.get_name()
   local cwd = vim.fn.getcwd()
-  
+
   if not session.exists(session_name) then
     vim.notify('Creating Q CLI session...', vim.log.levels.INFO)
-    
+
     local success, error_msg = session.create(session_name, cwd)
     if not success then
       vim.notify(error_msg, vim.log.levels.ERROR)
@@ -264,7 +265,7 @@ function M.toggle()
   else
     vim.notify('Connecting to existing session...', vim.log.levels.INFO)
   end
-  
+
   -- Open popup
   local success, error_msg = tmux.open_popup(session_name)
   if not success then
@@ -276,9 +277,9 @@ end
 function M.debug()
   local initialized, init_error = check_initialized()
   if not initialized then return end
-  
+
   local session_name = session.get_name()
-  
+
   print('=== Q CLI Debug Info ===')
   print('Session: ' .. session_name)
   print('Exists: ' .. tostring(session.exists(session_name)))
@@ -291,14 +292,14 @@ end
 function M.cleanup()
   local initialized, init_error = check_initialized()
   if not initialized then return end
-  
+
   local sessions = session.list_all()
-  
+
   if #sessions == 0 then
     vim.notify('No Q CLI sessions found to clean up', vim.log.levels.INFO)
     return
   end
-  
+
   local cleaned_count = 0
   for _, session_name in ipairs(sessions) do
     if session.kill(session_name) then
@@ -308,7 +309,7 @@ function M.cleanup()
       print('Failed to kill session: ' .. session_name)
     end
   end
-  
+
   vim.notify('Cleaned up ' .. cleaned_count .. ' Q CLI sessions', vim.log.levels.INFO)
 end
 
@@ -317,24 +318,24 @@ end
 function M.setup(opts)
   -- Validate and merge configuration
   local config = vim.tbl_deep_extend('force', DEFAULT_CONFIG, opts or {})
-  
+
   local valid, error_msg = utils.validate_config(config)
   if not valid then
     vim.notify('Invalid configuration: ' .. error_msg, vim.log.levels.ERROR)
     return
   end
-  
+
   -- Store configuration
   state.config = config
   state.initialized = true
-  
+
   -- Create user commands
   local commands = {
     { name = 'QToggle', func = M.toggle, desc = 'Toggle Q CLI popup' },
     { name = 'QDebug', func = M.debug, desc = 'Debug Q CLI session' },
     { name = 'QCleanup', func = M.cleanup, desc = 'Clean up Q CLI sessions' },
   }
-  
+
   for _, cmd in ipairs(commands) do
     vim.api.nvim_create_user_command(cmd.name, cmd.func, { desc = cmd.desc })
   end


### PR DESCRIPTION
### Description
Fix "unmatched quote" error when opening Q CLI popup by properly escaping shell arguments in the tmux display-popup command.

Changes:
- Replace double quotes with single quotes in popup title to avoid shell parsing conflicts
- Add vim.fn.shellescape() for session_name parameter to handle special characters
- Ensures robust command execution across different shell environments

Fixes shell command parsing error: "zsh:9: unmatched \""

### Testing
- Using my custom branch locally and now I can use this tool
- Earlier I would only get the error popup and wasnt opening the new popup for the plugin

